### PR TITLE
fixed programs api url

### DIFF
--- a/resources/lib/areena.py
+++ b/resources/lib/areena.py
@@ -197,15 +197,14 @@ def _playlist_url(series_id: str, ascending: bool, offset: int, page_size: int) 
         'type': 'program',
         'availability': '',
         'limit': str(page_size),
-        'order': f'episode.hash:{sort_order},publication.starttime:{sort_order},title.fi:asc',
+        'order': f'natural:{sort_order}',
         'app_id': 'areena_web_frontend_prod',
         'app_key': '4622a8f8505bb056c956832a70c105d4',
     }
     if offset:
         query['offset'] = str(offset)
     q = urlencode(query)
-    return f'https://areena.yle.fi/api/programs/v1/episodes/{series_id}.json?{q}'
-
+    return f'https://programs.api.yle.fi/v3/schema/v1/series/{series_id}/episodes?{q}'
 
 def _search_url(keyword: str, offset: int, page_size: int) -> str:
     q = urlencode({


### PR DESCRIPTION
I am getting 404 error on the old programs api. I found a working one here [https://docs.api.yle.fi/api/programs-api-v3](https://docs.api.yle.fi/api/programs-api-v3)

Since all the of episodes from different seasons are in same list, you might need to add some extra calls to fix that. 